### PR TITLE
Better handle not mapped microinverters.

### DIFF
--- a/hoymiles_modbus/client.py
+++ b/hoymiles_modbus/client.py
@@ -113,7 +113,7 @@ class HoymilesModbusTCP:
                 result = self._read_registers(client, start_address, 20, self._unit_id)
                 data_to_unpack = result.encode()[1:41]
                 if i < 1 and len(data_to_unpack) < 1:
-                    raise RuntimeError("No microinverters mapped yet.")
+                    raise RuntimeError("Microinverters not mapped yet.")
                 microinverter_data = self._microinverter_data_struct.unpack(
                     data_to_unpack)
                 if microinverter_data.serial_number == self._NULL_MICROINVERTER:

--- a/hoymiles_modbus/client.py
+++ b/hoymiles_modbus/client.py
@@ -111,7 +111,11 @@ class HoymilesModbusTCP:
             for i in range(self._MAX_MICROINVERTER_COUNT):
                 start_address = i * 40 + 0x1000
                 result = self._read_registers(client, start_address, 20, self._unit_id)
-                microinverter_data = self._microinverter_data_struct.unpack(result.encode()[1:41])
+                data_to_unpack = result.encode()[1:41]
+                if i < 1 and len(data_to_unpack) < 1:
+                    raise RuntimeError("No microinverters mapped yet.")
+                microinverter_data = self._microinverter_data_struct.unpack(
+                    data_to_unpack)
                 if microinverter_data.serial_number == self._NULL_MICROINVERTER:
                     break
                 data.append(microinverter_data)

--- a/tests/test_hoymiles_modbus.py
+++ b/tests/test_hoymiles_modbus.py
@@ -214,3 +214,13 @@ def test_modbus_response_exception():
         client_mock.read_holding_registers.return_value = ModbusIOException()
         with pytest.raises(ModbusIOException):
             client.HoymilesModbusTCP('1.2.3.4').dtu
+def test_exception_when_no_inverters():
+    """Test exception when there is no microinverters."""
+    client_mock = mock.Mock()
+    with mock.patch.object(client.ModbusTcpClient, '__enter__', return_value=client_mock):
+        client_mock.read_holding_registers.return_value.encode.side_effect = [b'']
+        client_mock.read_holding_registers.return_value.isError.return_value = False
+        hoymiles_modbus_tcp = client.HoymilesModbusTCP('1.2.3.4')
+        with pytest.raises(RuntimeError) as err:
+            hoymiles_modbus_tcp.microinverter_data
+        assert str(err.value) == "Microinverters not mapped yet."


### PR DESCRIPTION
Raise RuntimeError when microinverters are not mapped yet.

fixes #14 