### PR TITLE
0.6.3: Bumped into Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "hoymiles_modbus"
-version = "0.6.2"
+version = "0.6.3"
 homepage = "https://github.com/wasilukm/hoymiles_modbus"
 description = "Gather data from Hoymiles microinverters."
 authors = ["Foo Bar <foo@bar.com>"]
@@ -17,6 +17,7 @@ classifiers=[
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
 ]
 packages = [
     { include = "hoymiles_modbus" },
@@ -24,7 +25,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.8,<3.13"
 
 black  = {version = "22.3.0", optional = true}
 isort  = { version = "^5.8.0", optional = true}


### PR DESCRIPTION
Hoymiles Modbus supports Python 3.12 as-is. Bumped versions.