### PR TITLE
Add support for automatic detection of inverter type

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ DTU should be connected via its `Ethernet` port and should have IP address assig
 ## Features
 
 * Communication via Modbus TCP
-* Decode all microinverter status registers, which include information such as:
+* Decode all inverter status registers, which include information such as:
   * current production
   * total production
   * today production

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 
 
 
-Python library for gathering data from Hoymiles microinverters.
+Python library for gathering data from Hoymiles inverters.
 
 The library communicates with Hoymiles DTU (Pro and Pro-S are supported) which is
-a proxy/monitoring device for microinverters.
+a proxy/monitoring device for inverters.
 DTU should be connected via its `Ethernet` port and should have IP address assigned by DHCP server.
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,7 +1,5 @@
 # Usage
 
-To use hoymiles_modbus in a project
-
 ```
 from hoymiles_modbus.client import HoymilesModbusTCP
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,16 +9,3 @@ plant_data = HoymilesModbusTCP('1.2.3.4').plant_data
 print(plant_data.today_production)
 
 ```
-
-The above example assumes `MI` inverters, for `HM` change type as below:
-
-```
-from hoymiles_modbus.client import HoymilesModbusTCP
-from hoymiles_modbus.datatypes import MicroinverterType
-
-plant_data = HoymilesModbusTCP(
-    '1.2.3.4', microinverter_type=MicroinverterType.HM).plant_data
-print(plant_data.today_production)
-
-
-```

--- a/hoymiles_modbus/client.py
+++ b/hoymiles_modbus/client.py
@@ -1,18 +1,11 @@
 """Hoymiles Modbus client."""
 
 from dataclasses import asdict, dataclass
-from typing import List, Type, Union
 
 from pymodbus.client import ModbusTcpClient
 from pymodbus.framer.old_framer_socket import ModbusSocketFramer
 
-from .datatypes import (
-    HMSeriesMicroinverterData,
-    MicroinverterType,
-    MISeriesMicroinverterData,
-    PlantData,
-    _serial_number_t,
-)
+from .datatypes import InverterData, PlantData, _serial_number_t
 
 
 @dataclass
@@ -51,36 +44,26 @@ class _CustomSocketFramer(ModbusSocketFramer):
 class HoymilesModbusTCP:
     """Hoymiles Modbus TCP client.
 
-    Gather data from photovoltaic installation based on Hoymiles microinverters managed by Hoymiles DTU (like DTU-pro).
+    Gather data from photovoltaic installation based on Hoymiles inverters managed by Hoymiles DTU (like DTU-pro).
     The client communicates with DTU via Modbus TCP protocol.
 
     """
 
-    _MAX_MICROINVERTER_COUNT = 100
-    _NULL_MICROINVERTER = '000000000000'
+    _MAX_INVERTER_COUNT = 100
+    _NULL_INVERTER = '000000000000'
 
-    def __init__(
-        self, host: str, port: int = 502, microinverter_type: MicroinverterType = MicroinverterType.MI, unit_id: int = 1
-    ) -> None:
+    def __init__(self, host: str, port: int = 502, unit_id: int = 1) -> None:
         """Initialize the object.
 
         Arguments:
             host: DTU address
             port: target DTU modbus TCP port
-            microinverter_type: Microinverter type, applies to all microinverters
             unit_id: Modbus unit ID
 
         """
         self._host: str = host
         self._port: int = port
         self._dtu_serial_number: str = ''
-        self._microinverter_data_struct: Type[Union[MISeriesMicroinverterData, HMSeriesMicroinverterData]]
-        if microinverter_type == MicroinverterType.MI:
-            self._microinverter_data_struct = MISeriesMicroinverterData
-        elif microinverter_type == MicroinverterType.HM:
-            self._microinverter_data_struct = HMSeriesMicroinverterData
-        else:
-            raise ValueError('Unsupported microinverter type:', microinverter_type)
         self._unit_id = unit_id
         self._comm_params: CommunicationParams = CommunicationParams()
 
@@ -110,24 +93,24 @@ class HoymilesModbusTCP:
         return result
 
     @property
-    def microinverter_data(self) -> List[Union[MISeriesMicroinverterData, HMSeriesMicroinverterData]]:
-        """Status data from all microinverters.
+    def microinverter_data(self) -> list[InverterData]:
+        """Status data from all inverters.
 
         Each `get` is a new request and data from the installation.
 
         """
-        data: List[Union[MISeriesMicroinverterData, HMSeriesMicroinverterData]] = []
+        data: list[InverterData] = []
         with self._get_client() as client:
-            for i in range(self._MAX_MICROINVERTER_COUNT):
+            for i in range(self._MAX_INVERTER_COUNT):
                 start_address = i * 40 + 0x1000
                 result = self._read_registers(client, start_address, 20, self._unit_id)
                 data_to_unpack = result.encode()[1:41]
                 if i < 1 and len(data_to_unpack) < 1:
-                    raise RuntimeError("Microinverters not mapped yet.")
-                microinverter_data = self._microinverter_data_struct.unpack(data_to_unpack)
-                if microinverter_data.serial_number == self._NULL_MICROINVERTER:
+                    raise RuntimeError("Inverters not mapped yet.")
+                inverter_data = InverterData.unpack(data_to_unpack)
+                if inverter_data.serial_number == self._NULL_INVERTER:
                     break
-                data.append(microinverter_data)
+                data.append(inverter_data)
         return data
 
     @property
@@ -146,13 +129,13 @@ class HoymilesModbusTCP:
         Each `get` is a new request and data from the installation.
 
         """
-        microinverter_data = self.microinverter_data
-        data = PlantData(self.dtu, microinverter_data=microinverter_data)
-        for microinverter in microinverter_data:
-            if microinverter.link_status:
-                data.pv_power += microinverter.pv_power
-                data.today_production += microinverter.today_production
-                data.total_production += microinverter.total_production
-                if microinverter.alarm_code:
+        inverter_data = self.microinverter_data
+        data = PlantData(self.dtu, microinverter_data=inverter_data)
+        for inverter in inverter_data:
+            if inverter.link_status:
+                data.pv_power += inverter.pv_power
+                data.today_production += inverter.today_production
+                data.total_production += inverter.total_production
+                if inverter.alarm_code:
                     data.alarm_flag = True
         return data

--- a/hoymiles_modbus/client.py
+++ b/hoymiles_modbus/client.py
@@ -129,9 +129,11 @@ class HoymilesModbusTCP:
         Each `get` is a new request and data from the installation.
 
         """
-        inverter_data = self.inverters
-        data = PlantData(self.dtu, inverters=inverter_data)
-        for inverter in inverter_data:
+        inverters = self.inverters
+        data = PlantData(self.dtu, inverters=inverters)
+        for inverter in inverters:
+            # calculate plant data from inverters
+            # only active inverters are included
             if inverter.link_status:
                 data.pv_power += inverter.pv_power
                 data.today_production += inverter.today_production

--- a/hoymiles_modbus/client.py
+++ b/hoymiles_modbus/client.py
@@ -93,7 +93,7 @@ class HoymilesModbusTCP:
         return result
 
     @property
-    def microinverter_data(self) -> list[InverterData]:
+    def inverters(self) -> list[InverterData]:
         """Status data from all inverters.
 
         Each `get` is a new request and data from the installation.
@@ -129,8 +129,8 @@ class HoymilesModbusTCP:
         Each `get` is a new request and data from the installation.
 
         """
-        inverter_data = self.microinverter_data
-        data = PlantData(self.dtu, microinverter_data=inverter_data)
+        inverter_data = self.inverters
+        data = PlantData(self.dtu, inverters=inverter_data)
         for inverter in inverter_data:
             if inverter.link_status:
                 data.pv_power += inverter.pv_power

--- a/hoymiles_modbus/datatypes.py
+++ b/hoymiles_modbus/datatypes.py
@@ -47,7 +47,7 @@ _serial_number_t = _SerialNumberX(name='serial_number_t', nbytes=6)
 _reserved = ArrayX(name='reserved', fmt=uint8)
 
 
-class PVCurrentType(Enum):
+class _PVCurrentType(Enum):
     """PV current datatype depending on inverter type."""
 
     MI = _udec16p1
@@ -58,11 +58,15 @@ class PVCurrentType(Enum):
 
 def _pv_current_type(serial: str) -> DecimalX:
     if serial.startswith('10'):
-        current_type = PVCurrentType.MI.value
+        current_type = _PVCurrentType.MI.value
     elif serial.startswith('11'):
-        current_type = PVCurrentType.HM.value
+        current_type = _PVCurrentType.HM.value
+    elif serial == '000000000000':
+        # all zero serial number means empty inverter data
+        # in this case type of current value is not important
+        current_type = _PVCurrentType.MI.value
     else:
-        raise RuntimeError(f"Couldn't detect inverter type for serial {serial}." "Please report an issue.")
+        raise ValueError(f"Couldn't detect inverter type for serial {serial}. Please report an issue.")
     return current_type
 
 

--- a/hoymiles_modbus/datatypes.py
+++ b/hoymiles_modbus/datatypes.py
@@ -119,5 +119,5 @@ class PlantData:
     """Total production [Wh]."""
     alarm_flag: bool = False
     """Alarm indicator. True means that at least one inverter reported an alarm."""
-    microinverter_data: list[InverterData] = field(default_factory=list)
+    inverters: list[InverterData] = field(default_factory=list)
     """Data for each inverter."""

--- a/hoymiles_modbus/datatypes.py
+++ b/hoymiles_modbus/datatypes.py
@@ -77,31 +77,31 @@ class InverterData(Structure):  # type: ignore[misc]
     serial_number: str = member(fmt=_serial_number_t)
     """Inverter serial number."""
     port_number: int = member(fmt=uint8)
-    'Port number.'
+    """Port number."""
     pv_voltage: Decimal = member(fmt=_udec16p1)
-    'PV voltage [V].'
+    """PV voltage [V]."""
     pv_current: Decimal = member(fmt=_pv_current_type, fmt_arg=serial_number)  # type: ignore[arg-type]
-    'PV current [A].'
+    """PV current [A]."""
     grid_voltage: Decimal = member(fmt=_udec16p1)
-    'Grid voltage [V].'
+    """Grid voltage [V]."""
     grid_frequency: Decimal = member(fmt=_udec16p2)
-    'Grid frequency [Hz].'
+    """Grid frequency [Hz]."""
     pv_power: Decimal = member(fmt=_udec16p1)
-    'PV power [W].'
+    """PV power [W]."""
     today_production: int = member(fmt=uint16)
-    'Today production [Wh].'
+    """Today production [Wh]."""
     total_production: int = member(fmt=uint32)
-    'Total production [Wh].'
+    """Total production [Wh]."""
     temperature: Decimal = member(fmt=_sdec16p1)
-    'Inverter temperature [°C].'
+    """Inverter temperature [°C]."""
     operating_status: int = member(fmt=uint16)
-    'Operating status.'
+    """Operating status."""
     alarm_code: int = member(fmt=uint16)
-    'Alarm code.'
+    """Alarm code."""
     alarm_count: int = member(fmt=uint16)
-    'Alarm count.'
+    """Alarm count."""
     link_status: int = member(fmt=uint8)
-    'Link status.'
+    """Link status."""
     reserved: list[int] = member(fmt=_reserved)
 
 

--- a/hoymiles_modbus/datatypes.py
+++ b/hoymiles_modbus/datatypes.py
@@ -74,22 +74,34 @@ class InverterData(Structure):  # type: ignore[misc]
     """Inverter data structure."""
 
     data_type: int = member(fmt=uint8)
-    serial_number: str = member(fmt=_serial_number_t, doc='Inverter serial number.')
-    port_number: int = member(fmt=uint8, doc='Port number.')
-    pv_voltage: Decimal = member(fmt=_udec16p1, doc='PV voltage [V].')
-    pv_current: Decimal = member(
-        fmt=_pv_current_type, fmt_arg=serial_number, doc='PV current [A].'  # type: ignore[arg-type]
-    )
-    grid_voltage: Decimal = member(fmt=_udec16p1, doc='Grid voltage [V].')
-    grid_frequency: Decimal = member(fmt=_udec16p2, doc='Grid frequency [Hz].')
-    pv_power: Decimal = member(fmt=_udec16p1, doc='PV power [W].')
-    today_production: int = member(fmt=uint16, doc='Today production [Wh].')
-    total_production: int = member(fmt=uint32, doc='Total production [Wh].')
-    temperature: Decimal = member(fmt=_sdec16p1, doc='Inverter temperature [°C].')
-    operating_status: int = member(fmt=uint16, doc='Operating status.')
-    alarm_code: int = member(fmt=uint16, doc='Alarm code.')
-    alarm_count: int = member(fmt=uint16, doc='Alarm count.')
-    link_status: int = member(fmt=uint8, doc='Link status.')
+    serial_number: str = member(fmt=_serial_number_t)
+    """Inverter serial number."""
+    port_number: int = member(fmt=uint8)
+    'Port number.'
+    pv_voltage: Decimal = member(fmt=_udec16p1)
+    'PV voltage [V].'
+    pv_current: Decimal = member(fmt=_pv_current_type, fmt_arg=serial_number)  # type: ignore[arg-type]
+    'PV current [A].'
+    grid_voltage: Decimal = member(fmt=_udec16p1)
+    'Grid voltage [V].'
+    grid_frequency: Decimal = member(fmt=_udec16p2)
+    'Grid frequency [Hz].'
+    pv_power: Decimal = member(fmt=_udec16p1)
+    'PV power [W].'
+    today_production: int = member(fmt=uint16)
+    'Today production [Wh].'
+    total_production: int = member(fmt=uint32)
+    'Total production [Wh].'
+    temperature: Decimal = member(fmt=_sdec16p1)
+    'Inverter temperature [°C].'
+    operating_status: int = member(fmt=uint16)
+    'Operating status.'
+    alarm_code: int = member(fmt=uint16)
+    'Alarm code.'
+    alarm_count: int = member(fmt=uint16)
+    'Alarm count.'
+    link_status: int = member(fmt=uint8)
+    'Link status.'
     reserved: list[int] = member(fmt=_reserved)
 
 

--- a/hoymiles_modbus/datatypes.py
+++ b/hoymiles_modbus/datatypes.py
@@ -77,7 +77,9 @@ class InverterData(Structure):  # type: ignore[misc]
     serial_number: str = member(fmt=_serial_number_t, doc='Inverter serial number.')
     port_number: int = member(fmt=uint8, doc='Port number.')
     pv_voltage: Decimal = member(fmt=_udec16p1, doc='PV voltage [V].')
-    pv_current: Decimal = member(fmt=_pv_current_type, fmt_arg=serial_number, doc='PV current [A].')
+    pv_current: Decimal = member(
+        fmt=_pv_current_type, fmt_arg=serial_number, doc='PV current [A].'  # type: ignore[arg-type]
+    )
     grid_voltage: Decimal = member(fmt=_udec16p1, doc='Grid voltage [V].')
     grid_frequency: Decimal = member(fmt=_udec16p2, doc='Grid frequency [Hz].')
     pv_power: Decimal = member(fmt=_udec16p1, doc='PV power [W].')

--- a/poetry.lock
+++ b/poetry.lock
@@ -2005,4 +2005,4 @@ test = ["black", "flake8", "flake8-docstrings", "isort", "mypy", "pytest", "pyte
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "dc139a2d5cf8b72cc5671002a3f29226bac010cc99490c95aef297b2fd08cb26"
+content-hash = "7082bbd8425a0d9217d0fbc8c8f312553a6218390d90770639fb0165bdeb3340"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ pre-commit = {version = "^3.8.0", optional = true}
 toml = {version = "^0.10.2", optional = true}
 bump2version = {version = "^1.0.1", optional = true}
 plum-py = "^0.8.0"
-pymodbus = "^3.7"
+pymodbus = "3.7.2"
 
 [tool.poetry.extras]
 test = [

--- a/tests/test_hoymiles_modbus.py
+++ b/tests/test_hoymiles_modbus.py
@@ -38,8 +38,8 @@ example_unknown_series_raw_responses = [
 ]
 
 
-def test_microinverter_data_decode_mi_series():
-    """Test decoding microinverter data."""
+def test_inverters_data_decode_mi_series():
+    """Test decoding inverters data."""
     client_mock = mock.Mock()
     with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         client_mock.read_holding_registers.return_value.encode.side_effect = example_mi_series_raw_responses
@@ -64,12 +64,12 @@ def test_microinverter_data_decode_mi_series():
                 reserved=[7, 0, 0, 0, 0, 0, 0],
             )
         ]
-        microinverter_data = HoymilesModbusTCP('1.2.3.4').microinverter_data
-        assert microinverter_data == expected
+        inverters_data = HoymilesModbusTCP('1.2.3.4').inverters
+        assert inverters_data == expected
 
 
-def test_microinverter_data_decode_hm_series():
-    """Test decoding microinverter data."""
+def test_inverters_data_decode_hm_series():
+    """Test decoding inverters data."""
     client_mock = mock.Mock()
     with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         client_mock.read_holding_registers.return_value.encode.side_effect = example_hm_series_raw_responses
@@ -94,23 +94,23 @@ def test_microinverter_data_decode_hm_series():
                 reserved=[7, 0, 0, 0, 0, 0, 0],
             )
         ]
-        microinverter_data = HoymilesModbusTCP('1.2.3.4').microinverter_data
-        assert microinverter_data == expected
+        inverters_data = HoymilesModbusTCP('1.2.3.4').inverters
+        assert inverters_data == expected
 
 
-def test_unknown_microinverter_type():
-    """Test exception for unknown microinverter type."""
+def test_unknown_inverters_type():
+    """Test exception for unknown inverters type."""
     client_mock = mock.Mock()
     with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         client_mock.read_holding_registers.return_value.encode.side_effect = example_unknown_series_raw_responses
         client_mock.read_holding_registers.return_value.isError.return_value = False
 
         with pytest.raises(UnpackError):
-            _ = HoymilesModbusTCP('1.2.3.4').microinverter_data
+            _ = HoymilesModbusTCP('1.2.3.4').inverters
 
 
-def test_stop_microinverter_data_decode_on_empty_serial():
-    """Verify that requesting microinverter register stops on receiving first empty serial number."""
+def test_stop_inverters_data_decode_on_empty_serial():
+    """Verify that requesting inverters register stops on receiving first empty serial number."""
     client_mock = mock.Mock()
     with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         client_mock.read_holding_registers.return_value.encode.side_effect = example_mi_series_raw_responses + [
@@ -118,7 +118,7 @@ def test_stop_microinverter_data_decode_on_empty_serial():
             b'\x07\x00\x00\x00\x00\x00\x00'
         ]
         client_mock.read_holding_registers.return_value.isError.return_value = False
-        assert len(HoymilesModbusTCP('1.2.3.4').microinverter_data) == 1
+        assert len(HoymilesModbusTCP('1.2.3.4').inverters) == 1
 
 
 def test_dtu():
@@ -130,7 +130,7 @@ def test_dtu():
         assert HoymilesModbusTCP('1.2.3.4').dtu == '11d361600831'
 
 
-example_microinverter_data = [
+example_inverters_data = [
     InverterData(  # type: ignore[call-overload]
         data_type=12,
         serial_number='103332416355',
@@ -177,9 +177,9 @@ def test_plant_data():
         with mock.patch.object(HoymilesModbusTCP, 'dtu', new_callable=mock.PropertyMock, return_value='11d361600831'):
             with mock.patch.object(
                 HoymilesModbusTCP,
-                'microinverter_data',
+                'inverters',
                 new_callable=mock.PropertyMock,
-                return_value=example_microinverter_data,
+                return_value=example_inverters_data,
             ):
                 plant_data = HoymilesModbusTCP('1.2.3.4').plant_data
                 assert plant_data.dtu == '11d361600831'
@@ -189,7 +189,7 @@ def test_plant_data():
 
 def test_no_alarm():
     """Test inactive alarm in plant data."""
-    for data in example_microinverter_data:
+    for data in example_inverters_data:
         data.alarm_code = 0
 
     client_mock = mock.Mock()
@@ -197,9 +197,9 @@ def test_no_alarm():
         with mock.patch.object(HoymilesModbusTCP, 'dtu', new_callable=mock.PropertyMock, return_value='11d361600831'):
             with mock.patch.object(
                 HoymilesModbusTCP,
-                'microinverter_data',
+                'inverters',
                 new_callable=mock.PropertyMock,
-                return_value=example_microinverter_data,
+                return_value=example_inverters_data,
             ):
                 plant_data = HoymilesModbusTCP('1.2.3.4').plant_data
                 assert plant_data.alarm_flag is False
@@ -207,16 +207,16 @@ def test_no_alarm():
 
 def test_alarm():
     """Test active alarm in plant data."""
-    example_microinverter_data[0].alarm_code = 1
+    example_inverters_data[0].alarm_code = 1
 
     client_mock = mock.Mock()
     with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         with mock.patch.object(HoymilesModbusTCP, 'dtu', new_callable=mock.PropertyMock, return_value='11d361600831'):
             with mock.patch.object(
                 HoymilesModbusTCP,
-                'microinverter_data',
+                'inverters',
                 new_callable=mock.PropertyMock,
-                return_value=example_microinverter_data,
+                return_value=example_inverters_data,
             ):
                 plant_data = HoymilesModbusTCP('1.2.3.4').plant_data
                 assert plant_data.alarm_flag is True
@@ -234,12 +234,12 @@ def test_modbus_response_exception():
 
 
 def test_exception_when_no_inverters():
-    """Test exception when there is no microinverters."""
+    """Test exception when there is no inverterss."""
     client_mock = mock.Mock()
     with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         client_mock.read_holding_registers.return_value.encode.side_effect = [b'']
         client_mock.read_holding_registers.return_value.isError.return_value = False
         hoymiles_modbus_tcp = HoymilesModbusTCP('1.2.3.4')
         with pytest.raises(RuntimeError) as err:
-            hoymiles_modbus_tcp.microinverter_data
+            hoymiles_modbus_tcp.inverters
         assert str(err.value) == "Inverters not mapped yet."

--- a/tests/test_hoymiles_modbus.py
+++ b/tests/test_hoymiles_modbus.py
@@ -39,7 +39,7 @@ example_unknown_series_raw_responses = [
 
 
 def test_inverter_data_decode_mi_series():
-    """Test decoding MI series inverters data."""
+    """Test decoding MI series inverter data."""
     client_mock = mock.Mock()
     with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         client_mock.read_holding_registers.return_value.encode.side_effect = example_mi_series_raw_responses
@@ -110,7 +110,7 @@ def test_unknown_inverter_type():
 
 
 def test_stop_inverter_data_decode_on_empty_serial():
-    """Verify that requesting inverters register stops on receiving first empty serial number."""
+    """Verify that inverters data gathering stops on receiving first empty serial number."""
     client_mock = mock.Mock()
     with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         client_mock.read_holding_registers.return_value.encode.side_effect = example_mi_series_raw_responses + [
@@ -234,7 +234,7 @@ def test_modbus_response_exception():
 
 
 def test_exception_when_no_inverters():
-    """Test exception when there is no inverterss."""
+    """Test exception when there are no inverters."""
     client_mock = mock.Mock()
     with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         client_mock.read_holding_registers.return_value.encode.side_effect = [b'']

--- a/tests/test_hoymiles_modbus.py
+++ b/tests/test_hoymiles_modbus.py
@@ -38,8 +38,8 @@ example_unknown_series_raw_responses = [
 ]
 
 
-def test_inverters_data_decode_mi_series():
-    """Test decoding inverters data."""
+def test_inverter_data_decode_mi_series():
+    """Test decoding MI series inverters data."""
     client_mock = mock.Mock()
     with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         client_mock.read_holding_registers.return_value.encode.side_effect = example_mi_series_raw_responses
@@ -68,8 +68,8 @@ def test_inverters_data_decode_mi_series():
         assert inverters_data == expected
 
 
-def test_inverters_data_decode_hm_series():
-    """Test decoding inverters data."""
+def test_inverter_data_decode_hm_series():
+    """Test decoding HM inverter data."""
     client_mock = mock.Mock()
     with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         client_mock.read_holding_registers.return_value.encode.side_effect = example_hm_series_raw_responses
@@ -98,8 +98,8 @@ def test_inverters_data_decode_hm_series():
         assert inverters_data == expected
 
 
-def test_unknown_inverters_type():
-    """Test exception for unknown inverters type."""
+def test_unknown_inverter_type():
+    """Test exception for unknown inverter type."""
     client_mock = mock.Mock()
     with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         client_mock.read_holding_registers.return_value.encode.side_effect = example_unknown_series_raw_responses
@@ -109,7 +109,7 @@ def test_unknown_inverters_type():
             _ = HoymilesModbusTCP('1.2.3.4').inverters
 
 
-def test_stop_inverters_data_decode_on_empty_serial():
+def test_stop_inverter_data_decode_on_empty_serial():
     """Verify that requesting inverters register stops on receiving first empty serial number."""
     client_mock = mock.Mock()
     with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
@@ -230,7 +230,7 @@ def test_modbus_response_exception():
         response.isError.return_value = True
         client_mock.read_holding_registers.return_value = response
         with pytest.raises(RuntimeError):
-            HoymilesModbusTCP('1.2.3.4').dtu
+            _ = HoymilesModbusTCP('1.2.3.4').dtu
 
 
 def test_exception_when_no_inverters():
@@ -241,5 +241,5 @@ def test_exception_when_no_inverters():
         client_mock.read_holding_registers.return_value.isError.return_value = False
         hoymiles_modbus_tcp = HoymilesModbusTCP('1.2.3.4')
         with pytest.raises(RuntimeError) as err:
-            hoymiles_modbus_tcp.inverters
+            _ = hoymiles_modbus_tcp.inverters
         assert str(err.value) == "Inverters not mapped yet."

--- a/tests/test_hoymiles_modbus.py
+++ b/tests/test_hoymiles_modbus.py
@@ -1,16 +1,35 @@
 #!/usr/bin/env python
 """Tests for `hoymiles_modbus` package."""
-
 from decimal import Decimal
 from unittest import mock
 
 import pytest
+from plum.exceptions import UnpackError
 
-from hoymiles_modbus import client
-from hoymiles_modbus.datatypes import HMSeriesMicroinverterData, MicroinverterType, MISeriesMicroinverterData
+from hoymiles_modbus.client import HoymilesModbusTCP, ModbusTcpClient
+from hoymiles_modbus.datatypes import InverterData
 
-example_raw_modbus_responses = [
+example_mi_series_raw_responses = [
     b'(\x0c\x1032\x41cU\x01\x01^\x00\x02\tM\x13\x88\x00f\x02\xef\x00\x01$G\x00+\x00\x03\x00\x00\x00\x00\x01'
+    b'\x07\x00\x00\x00\x00\x00\x00',
+    b'P\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    b'\x00\x00\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    b'\x00\x00\x00',
+]
+
+example_hm_series_raw_responses = [
+    b'(\x0c\x1132\x41cU\x01\x01^\x00\x02\tM\x13\x88\x00f\x02\xef\x00\x01$G\x00+\x00\x03\x00\x00\x00\x00\x01'
+    b'\x07\x00\x00\x00\x00\x00\x00',
+    b'P\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    b'\x00\x00\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    b'\x00\x00\x00',
+]
+
+
+example_unknown_series_raw_responses = [
+    b'(\x0c\x1232\x41cU\x01\x01^\x00\x02\tM\x13\x88\x00f\x02\xef\x00\x01$G\x00+\x00\x03\x00\x00\x00\x00\x01'
     b'\x07\x00\x00\x00\x00\x00\x00',
     b'P\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
     b'\x00\x00\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
@@ -22,11 +41,11 @@ example_raw_modbus_responses = [
 def test_microinverter_data_decode_mi_series():
     """Test decoding microinverter data."""
     client_mock = mock.Mock()
-    with mock.patch.object(client.ModbusTcpClient, '__enter__', return_value=client_mock):
-        client_mock.read_holding_registers.return_value.encode.side_effect = example_raw_modbus_responses
+    with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
+        client_mock.read_holding_registers.return_value.encode.side_effect = example_mi_series_raw_responses
         client_mock.read_holding_registers.return_value.isError.return_value = False
         expected = [
-            MISeriesMicroinverterData(
+            InverterData(
                 data_type=12,
                 serial_number='103332416355',
                 port_number=1,
@@ -45,20 +64,20 @@ def test_microinverter_data_decode_mi_series():
                 reserved=[7, 0, 0, 0, 0, 0, 0],
             )
         ]
-        microinverter_data = client.HoymilesModbusTCP('1.2.3.4').microinverter_data
+        microinverter_data = HoymilesModbusTCP('1.2.3.4').microinverter_data
         assert microinverter_data == expected
 
 
 def test_microinverter_data_decode_hm_series():
     """Test decoding microinverter data."""
     client_mock = mock.Mock()
-    with mock.patch.object(client.ModbusTcpClient, '__enter__', return_value=client_mock):
-        client_mock.read_holding_registers.return_value.encode.side_effect = example_raw_modbus_responses
+    with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
+        client_mock.read_holding_registers.return_value.encode.side_effect = example_hm_series_raw_responses
         client_mock.read_holding_registers.return_value.isError.return_value = False
         expected = [
-            HMSeriesMicroinverterData(
+            InverterData(
                 data_type=12,
-                serial_number='103332416355',
+                serial_number='113332416355',
                 port_number=1,
                 pv_voltage=Decimal('35'),
                 pv_current=Decimal('0.02'),
@@ -75,41 +94,44 @@ def test_microinverter_data_decode_hm_series():
                 reserved=[7, 0, 0, 0, 0, 0, 0],
             )
         ]
-        microinverter_data = client.HoymilesModbusTCP(
-            '1.2.3.4', microinverter_type=MicroinverterType.HM
-        ).microinverter_data
+        microinverter_data = HoymilesModbusTCP('1.2.3.4').microinverter_data
         assert microinverter_data == expected
 
 
 def test_unknown_microinverter_type():
     """Test exception for unknown microinverter type."""
-    with pytest.raises(ValueError):
-        client.HoymilesModbusTCP('1.2.3.4', microinverter_type='foo')
+    client_mock = mock.Mock()
+    with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
+        client_mock.read_holding_registers.return_value.encode.side_effect = example_unknown_series_raw_responses
+        client_mock.read_holding_registers.return_value.isError.return_value = False
+
+        with pytest.raises(UnpackError):
+            _ = HoymilesModbusTCP('1.2.3.4').microinverter_data
 
 
 def test_stop_microinverter_data_decode_on_empty_serial():
     """Verify that requesting microinverter register stops on receiving first empty serial number."""
     client_mock = mock.Mock()
-    with mock.patch.object(client.ModbusTcpClient, '__enter__', return_value=client_mock):
-        client_mock.read_holding_registers.return_value.encode.side_effect = example_raw_modbus_responses + [
+    with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
+        client_mock.read_holding_registers.return_value.encode.side_effect = example_mi_series_raw_responses + [
             b'(\x0c\x1032\x41cU\x01\x01^\x00\x02\tM\x13\x88\x00f\x02\xef\x00\x01$G\x00+\x00\x03\x00\x00\x00\x00\x01'
             b'\x07\x00\x00\x00\x00\x00\x00'
         ]
         client_mock.read_holding_registers.return_value.isError.return_value = False
-        assert len(client.HoymilesModbusTCP('1.2.3.4').microinverter_data) == 1
+        assert len(HoymilesModbusTCP('1.2.3.4').microinverter_data) == 1
 
 
 def test_dtu():
     """Test decoding DTU serial number."""
     client_mock = mock.Mock()
-    with mock.patch.object(client.ModbusTcpClient, '__enter__', return_value=client_mock):
+    with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         client_mock.read_holding_registers.return_value.encode.side_effect = [b'\x06\x11\xd3a`\x081']
         client_mock.read_holding_registers.return_value.isError.return_value = False
-        assert client.HoymilesModbusTCP('1.2.3.4').dtu == '11d361600831'
+        assert HoymilesModbusTCP('1.2.3.4').dtu == '11d361600831'
 
 
 example_microinverter_data = [
-    MISeriesMicroinverterData(  # type: ignore[call-overload]
+    InverterData(  # type: ignore[call-overload]
         data_type=12,
         serial_number='103332416355',
         port_number=1,
@@ -127,7 +149,7 @@ example_microinverter_data = [
         link_status=1,
         reserved=[7, 0, 0, 0, 0, 0, 0],
     ),
-    MISeriesMicroinverterData(  # type: ignore[call-overload]
+    InverterData(  # type: ignore[call-overload]
         data_type=12,
         serial_number='117763504101',
         port_number=1,
@@ -151,17 +173,15 @@ example_microinverter_data = [
 def test_plant_data():
     """Test calculated values in plant data."""
     client_mock = mock.Mock()
-    with mock.patch.object(client.ModbusTcpClient, '__enter__', return_value=client_mock):
-        with mock.patch.object(
-            client.HoymilesModbusTCP, 'dtu', new_callable=mock.PropertyMock, return_value='11d361600831'
-        ):
+    with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
+        with mock.patch.object(HoymilesModbusTCP, 'dtu', new_callable=mock.PropertyMock, return_value='11d361600831'):
             with mock.patch.object(
-                client.HoymilesModbusTCP,
+                HoymilesModbusTCP,
                 'microinverter_data',
                 new_callable=mock.PropertyMock,
                 return_value=example_microinverter_data,
             ):
-                plant_data = client.HoymilesModbusTCP('1.2.3.4').plant_data
+                plant_data = HoymilesModbusTCP('1.2.3.4').plant_data
                 assert plant_data.dtu == '11d361600831'
                 assert plant_data.today_production == 1430
                 assert plant_data.total_production == 129151
@@ -173,17 +193,15 @@ def test_no_alarm():
         data.alarm_code = 0
 
     client_mock = mock.Mock()
-    with mock.patch.object(client.ModbusTcpClient, '__enter__', return_value=client_mock):
-        with mock.patch.object(
-            client.HoymilesModbusTCP, 'dtu', new_callable=mock.PropertyMock, return_value='11d361600831'
-        ):
+    with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
+        with mock.patch.object(HoymilesModbusTCP, 'dtu', new_callable=mock.PropertyMock, return_value='11d361600831'):
             with mock.patch.object(
-                client.HoymilesModbusTCP,
+                HoymilesModbusTCP,
                 'microinverter_data',
                 new_callable=mock.PropertyMock,
                 return_value=example_microinverter_data,
             ):
-                plant_data = client.HoymilesModbusTCP('1.2.3.4').plant_data
+                plant_data = HoymilesModbusTCP('1.2.3.4').plant_data
                 assert plant_data.alarm_flag is False
 
 
@@ -192,38 +210,36 @@ def test_alarm():
     example_microinverter_data[0].alarm_code = 1
 
     client_mock = mock.Mock()
-    with mock.patch.object(client.ModbusTcpClient, '__enter__', return_value=client_mock):
-        with mock.patch.object(
-            client.HoymilesModbusTCP, 'dtu', new_callable=mock.PropertyMock, return_value='11d361600831'
-        ):
+    with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
+        with mock.patch.object(HoymilesModbusTCP, 'dtu', new_callable=mock.PropertyMock, return_value='11d361600831'):
             with mock.patch.object(
-                client.HoymilesModbusTCP,
+                HoymilesModbusTCP,
                 'microinverter_data',
                 new_callable=mock.PropertyMock,
                 return_value=example_microinverter_data,
             ):
-                plant_data = client.HoymilesModbusTCP('1.2.3.4').plant_data
+                plant_data = HoymilesModbusTCP('1.2.3.4').plant_data
                 assert plant_data.alarm_flag is True
 
 
 def test_modbus_response_exception():
     """Verify that exception is raised when error in modbus response."""
     client_mock = mock.Mock()
-    with mock.patch.object(client.ModbusTcpClient, '__enter__', return_value=client_mock):
+    with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         response = mock.Mock()
         response.isError.return_value = True
         client_mock.read_holding_registers.return_value = response
         with pytest.raises(RuntimeError):
-            client.HoymilesModbusTCP('1.2.3.4').dtu
+            HoymilesModbusTCP('1.2.3.4').dtu
 
 
 def test_exception_when_no_inverters():
     """Test exception when there is no microinverters."""
     client_mock = mock.Mock()
-    with mock.patch.object(client.ModbusTcpClient, '__enter__', return_value=client_mock):
+    with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
         client_mock.read_holding_registers.return_value.encode.side_effect = [b'']
         client_mock.read_holding_registers.return_value.isError.return_value = False
-        hoymiles_modbus_tcp = client.HoymilesModbusTCP('1.2.3.4')
+        hoymiles_modbus_tcp = HoymilesModbusTCP('1.2.3.4')
         with pytest.raises(RuntimeError) as err:
             hoymiles_modbus_tcp.microinverter_data
-        assert str(err.value) == "Microinverters not mapped yet."
+        assert str(err.value) == "Inverters not mapped yet."


### PR DESCRIPTION
Inverter type is auto-detected, supported inverter series are `MI` (serial number starting with 10) and `HM` (serial number starting with 11)

This includes breaking changes:

- removed `microinverter_type` parameter from `HoymilesModbusTCP`
- data structures MISeriesMicroinverterData and replaced by InverterData
- renamed `PlantData.microinverter_data` to `PlantData.inverters`
- renamed `HoymilesModbusTCP.microinverter_data` to `HoymilesModbusTCP.inverters`

