### PR TITLE
Change logic of inverter type detection

### DIFF
--- a/hoymiles_modbus/datatypes.py
+++ b/hoymiles_modbus/datatypes.py
@@ -57,16 +57,9 @@ class _PVCurrentType(Enum):
 
 
 def _pv_current_type(serial: str) -> DecimalX:
+    current_type = _PVCurrentType.HM.value
     if serial.startswith('10'):
         current_type = _PVCurrentType.MI.value
-    elif serial.startswith('11'):
-        current_type = _PVCurrentType.HM.value
-    elif serial == '000000000000':
-        # all zero serial number means empty inverter data
-        # in this case type of current value is not important
-        current_type = _PVCurrentType.MI.value
-    else:
-        raise ValueError(f"Couldn't detect inverter type for serial {serial}. Please report an issue.")
     return current_type
 
 

--- a/tests/test_hoymiles_modbus.py
+++ b/tests/test_hoymiles_modbus.py
@@ -4,7 +4,6 @@ from decimal import Decimal
 from unittest import mock
 
 import pytest
-from plum.exceptions import UnpackError
 
 from hoymiles_modbus._modbus_tcp_client import ModbusTcpClient
 from hoymiles_modbus.client import HoymilesModbusTCP
@@ -97,17 +96,6 @@ def test_inverter_data_decode_hm_series():
         ]
         inverters_data = HoymilesModbusTCP('1.2.3.4').inverters
         assert inverters_data == expected
-
-
-def test_unknown_inverter_type():
-    """Test exception for unknown inverter type."""
-    client_mock = mock.Mock()
-    with mock.patch.object(ModbusTcpClient, '__enter__', return_value=client_mock):
-        client_mock.read_holding_registers.return_value.encode.side_effect = example_unknown_series_raw_responses
-        client_mock.read_holding_registers.return_value.isError.return_value = False
-
-        with pytest.raises(UnpackError):
-            _ = HoymilesModbusTCP('1.2.3.4').inverters
 
 
 def test_stop_inverter_data_decode_on_empty_serial():


### PR DESCRIPTION
By default, all inverters are treated as HM series. Only inverters with serial numbers starting with "10" are treated as MI series.
This should cover more inverters without updating the library for every new inverter model.

Note: the knowledge of inverter type is needed for correct decoding pv_current.